### PR TITLE
export standalone codec (encoding and decoding functions)

### DIFF
--- a/codec.js
+++ b/codec.js
@@ -1,0 +1,66 @@
+function encodeControl(channel, command, length) {
+  var CONTROL_LENGTH = 4;
+  var buffer = Buffer.alloc(CONTROL_LENGTH);
+  buffer.writeUInt8(channel, 0); // Channel
+  buffer.writeUInt8(command, 1); // Command
+  buffer.writeUInt16BE(length, 2); // Data length
+  return buffer;
+}
+
+function encodeMessage(channel, command, data) {
+  var control = encodeControl(channel, command, data.length);
+  return Buffer.concat([control, data]);
+}
+
+function encodePixelsMessage(channel, pixels) {
+  return encodeMessage(channel, 0, pixels);
+}
+
+function encodeSetGlobalColorCorrectionMessage(config) {
+  var json = JSON.stringify(config);
+  var data = Buffer.alloc(Buffer.byteLength(json) + 4);
+  data.writeUInt16BE(0x0001, 0); // System ID ("Fadecandy")
+  data.writeUInt16BE(0x0001, 2); // SysEx ID ("Set Global Color Correction")
+  data.write(json, 4); // data
+  return encodeMessage(0, 0xff, data);
+}
+
+function decodeMessage (read, callback) {
+  var message = {};
+  // read channel
+  read(1, function(data) {
+    message.channel = data.readUInt8(0);
+    // read command
+    read(1, function(data) {
+      message.command = data.readUInt8(0);
+      // read data length
+      read(2, function(data) {
+        var length = data.readUInt16BE(0);
+        // read data
+        read(length, function(data) {
+          message.data = data;
+          // done!
+          callback(message);
+        });
+      });
+    });
+  });
+}
+
+function decodeAllMessages(read, callback) {
+  (function next() {
+    decodeMessage(read, function(message) {
+      callback(message);
+      next();
+    });
+  })();
+}
+
+module.exports = {
+  encodeControl: encodeControl,
+  encodeMessage: encodeMessage,
+  encodePixelsMessage: encodePixelsMessage,
+  encodeSetGlobalColorCorrectionMessage: encodeSetGlobalColorCorrectionMessage,
+  decodeMessage: decodeMessage,
+  decodeAllMessages: decodeAllMessages
+};

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
 
 var util = require('util');
 var PassThrough = require('stream').PassThrough;
+var Codec = require('./codec');
 
 function OPCStream() {
   PassThrough.call(this);
@@ -15,43 +16,16 @@ function OPCStream() {
 util.inherits(OPCStream, PassThrough);
 
 OPCStream.prototype.writeMessage = function(channel, command, data) {
-  return this.write(createMessage(channel, command, data));
+  return this.write(Codec.encodeMessage(channel, command, data));
 };
 
 OPCStream.prototype.writePixels = function(channel, pixels) {
-  return this.write(createPixelsMessage(channel, pixels));
+  return this.write(Codec.encodePixelsMessage(channel, pixels));
 };
 
 OPCStream.prototype.writeColorCorrection = function(config) {
-  return this.write(createSetGlobalColorCorrectionMessage(config));
+  return this.write(Codec.encodeSetGlobalColorCorrectionMessage(config));
 };
-
-function createPixelsMessage(channel, pixels) {
-  return createMessage(channel, 0, pixels);
-}
-
-function createSetGlobalColorCorrectionMessage(config) {
-  var json = JSON.stringify(config);
-  var data = Buffer.alloc(Buffer.byteLength(json) + 4);
-  data.writeUInt16BE(0x0001, 0); // System ID ("Fadecandy")
-  data.writeUInt16BE(0x0001, 2); // SysEx ID ("Set Global Color Correction")
-  data.write(json, 4); // data
-  return createMessage(0, 0xff, data);
-}
-
-function createMessage(channel, command, data) {
-  var control = createControl(channel, command, data.length);
-  return Buffer.concat([control, data]);
-}
-
-function createControl(channel, command, length) {
-  var CONTROL_LENGTH = 4;
-  var buffer = Buffer.alloc(CONTROL_LENGTH);
-  buffer.writeUInt8(channel, 0); // Channel
-  buffer.writeUInt8(command, 1); // Command
-  buffer.writeUInt16BE(length, 2); // Data length
-  return buffer;
-}
 
 // @TODO Set Firmware Configuration
 

--- a/parser.js
+++ b/parser.js
@@ -3,41 +3,11 @@
 var through = require("through2");
 var parse = require("parse-binary-stream");
 var duplexer = require("duplexer2");
-
-function parseMessage(read, callback) {
-  var message = {};
-  // read channel
-  read(1, function(data) {
-    message.channel = data.readUInt8(0);
-    // read command
-    read(1, function(data) {
-      message.command = data.readUInt8(0);
-      // read data length
-      read(2, function(data) {
-        var length = data.readUInt16BE(0);
-        // read data
-        read(length, function(data) {
-          message.data = data;
-          // done!
-          callback(message);
-        });
-      });
-    });
-  });
-}
-
-function parseAllMessages(read, callback) {
-  (function next() {
-    parseMessage(read, function(message) {
-      callback(message);
-      next();
-    });
-  })();
-}
+var Codec = require("./codec");
 
 module.exports = function() {
   var parser = parse(function(read) {
-    parseAllMessages(read, function(message) {
+    Codec.decodeAllMessages(read, function(message) {
       output.push(message);
     });
   });


### PR DESCRIPTION
and rename `create*` to `encode*` and `parse*` to `decode*`

---

my use case for this change is to use [pull streams](pull-stream.github.io) instead of node streams: [`pull-opc`](https://github.com/ahdinosaur/pull-opc)